### PR TITLE
fix boost archive URLs

### DIFF
--- a/boost/1.70.0/package.py
+++ b/boost/1.70.0/package.py
@@ -44,7 +44,7 @@ def commands():
 
 def pre_cook():
     download_and_unpack(
-        f"https://boostorg.jfrog.io/artifactory/main/release/{version}/source/boost_{version.replace('.', '_')}.tar.bz2",
+        f"https://archives.boost.io/release/{version}/source/boost_{version.replace('.', '_')}.tar.bz2",
     )
 
 

--- a/boost/1.73.0/package.py
+++ b/boost/1.73.0/package.py
@@ -45,7 +45,7 @@ def commands():
 
 def pre_cook():
     download_and_unpack(
-        f"https://boostorg.jfrog.io/artifactory/main/release/{version}/source/boost_{version.replace('.', '_')}.tar.bz2",
+        f"https://archives.boost.io/release/{version}/source/boost_{version.replace('.', '_')}.tar.bz2",
     )
 
 

--- a/boost/1.76.0/package.py
+++ b/boost/1.76.0/package.py
@@ -45,7 +45,7 @@ def commands():
 
 def pre_cook():
     download_and_unpack(
-        f"https://boostorg.jfrog.io/artifactory/main/release/{version}/source/boost_{version.replace('.', '_')}.tar.bz2",
+        f"https://archives.boost.io/release/{version}/source/boost_{version.replace('.', '_')}.tar.bz2",
     )
 
 

--- a/boost/1.79.0/package.py
+++ b/boost/1.79.0/package.py
@@ -44,7 +44,7 @@ def commands():
 
 def pre_cook():
     download_and_unpack(
-        f"https://boostorg.jfrog.io/artifactory/main/release/{version}/source/boost_{version.replace('.', '_')}.tar.bz2",
+        f"https://archives.boost.io/release/{version}/source/boost_{version.replace('.', '_')}.tar.bz2",
     )
 
 

--- a/boost/1.80.0/package.py
+++ b/boost/1.80.0/package.py
@@ -44,7 +44,7 @@ def commands():
 
 def pre_cook():
     download_and_unpack(
-        f"https://boostorg.jfrog.io/artifactory/main/release/{version}/source/boost_{version.replace('.', '_')}.tar.bz2",
+        f"https://archives.boost.io/release/{version}/source/boost_{version.replace('.', '_')}.tar.bz2",
     )
 
 

--- a/boost/1.82.0/package.py
+++ b/boost/1.82.0/package.py
@@ -44,7 +44,7 @@ def commands():
 
 def pre_cook():
     download_and_unpack(
-        f"https://boostorg.jfrog.io/artifactory/main/release/{version}/source/boost_{version.replace('.', '_')}.tar.bz2",
+        f"https://archives.boost.io/release/{version}/source/boost_{version.replace('.', '_')}.tar.bz2",
     )
 
 


### PR DESCRIPTION
the urls here to download boost are a bit outdated.
This PR updates them to use `https://archives.boost.io`